### PR TITLE
fix

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,6 +29,6 @@ jobs:
             username: ${{ secrets.SFTP_USERNAME }}
             password: ${{ secrets.SFTP_PASSWORD }}
             port: ${{ secrets.SFTP_PORT }}
-            local_path: './build'
+            local_path: './build/*'
             remote_path: './fip/generator'
             sftp_only: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts the GitHub Actions SFTP deploy step to upload the contents of `build` by changing `local_path` from `./build` to `./build/*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f397a897920c31eddc5bbe69fec0bd613c29855a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->